### PR TITLE
fix: add missing `http` dependency to manifest

### DIFF
--- a/custom_components/family_treasury/manifest.json
+++ b/custom_components/family_treasury/manifest.json
@@ -4,12 +4,12 @@
   "codeowners": [
     "@trevorswanson"
   ],
+  "config_flow": true,
   "dependencies": [
     "frontend",
     "http",
     "lovelace"
   ],
-  "config_flow": true,
   "documentation": "https://github.com/trevorswanson/ha-family-treasury",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/trevorswanson/ha-family-treasury/issues",


### PR DESCRIPTION
## Linked Issue

- Closes #15 

## Summary

Adds `http` to the dependencies for this integration's `manifest.json`

## Type Of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation only
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `test`: Adds or updates tests
- [ ] `chore/ci/build/style/perf`: Maintenance or pipeline change

## User-Facing Impact

- [ ] User-facing behavior changed
- [x] No user-facing behavior change

## Implementation Notes

List important design details, tradeoffs, or migration impacts.

## Testing

- [x] I ran tests locally (`tox` or targeted equivalent)
- [x] I added/updated tests for my changes
- [x] New/changed Python lines in `custom_components/family_treasury/` are covered by tests
- [x] I verified critical paths manually (if applicable)

## Documentation Impact

- [x] Docs impact assessed
- [x] I updated relevant docs pages in `docs/`
- [x] I updated examples (`examples/*.yaml`) when needed

No docs update needed because:

```text
This is a change to the manifest but does not have any impact on functionality
```

## Checklist

- [x] PR links an existing issue
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included
- [x] This PR is ready for review
